### PR TITLE
Fix formatting and typos in CGI and chat scripts

### DIFF
--- a/sall.cgi
+++ b/sall.cgi
@@ -17,17 +17,20 @@ def main
   user_sentence_new  = cgi["user_sentence_new"]
   nowstr = Time::now.strftime("%F %T")
   if user_sentence != "" or assistant_sentence != ""
-    user_name = "Visiter" if user_name == ""
+    user_name = "Visitor" if user_name == ""
     assistant_name = "Assistant" if assistant_name == ""
-    pasttalk = sprintf("時刻 %s のユーザの「%s」としての発言: %s\n" \
-      +             "時刻 %s のassistantの「%s」としての発言: %s\n", \
-      nowstr, nowstr, user_name, user_sentence, assistant_name, assistant_sentence)
+    pasttalk = sprintf(
+      "時刻 %s のユーザの「%s」としての発言: %s\n" +
+      "時刻 %s のassistantの「%s」としての発言: %s\n",
+      nowstr, user_name, user_sentence,
+      nowstr, assistant_name, assistant_sentence
+    )
   else
     pasttalk = ""
   end
   timestr = ""
   user_name = user_name_new
-  user_name = "Visiter" if user_name == ""
+  user_name = "Visitor" if user_name == ""
   assistant_name = assistant_name_new
   assistant_name = "Assistant" if assistant_name == ""
   user_sentence = user_sentence_new
@@ -114,7 +117,7 @@ Content-type: text/html
       <input type="submit" name="submit" value="OK" />
       &nbsp; &nbsp;
       <input type="submit" name="submit" value="CLEAR" />
-      </dev>
+      </div>
     </form>
     <br />
   </body>

--- a/sall.rb
+++ b/sall.rb
@@ -64,9 +64,12 @@ def main()
       time = Time::now - time0
       printf("%s(%.1f sec,%s,%d,%d) %s : %s\n", Time::now.strftime("%T"), time, model, insize, outsize, assistant_name, assistant_sentence)
       nowstr = Time::now.strftime("%F %T")
-      pasttalk = sprintf("時刻 %s のユーザの「%s」としての発言: %s\n" \
-        +             "時刻 %s のassistantの「%s」としての発言: %s\n", \
-        nowstr, nowstr, user_name, user_sentence, assistant_name, assistant_sentence)
+      pasttalk = sprintf(
+        "時刻 %s のユーザの「%s」としての発言: %s\n" +
+        "時刻 %s のassistantの「%s」としての発言: %s\n",
+        nowstr, user_name, user_sentence,
+        nowstr, assistant_name, assistant_sentence
+      )
     end
   end
 end

--- a/sall_oa.cgi
+++ b/sall_oa.cgi
@@ -17,17 +17,20 @@ def main
   user_sentence_new  = cgi["user_sentence_new"]
   nowstr = Time::now.strftime("%F %T")
   if user_sentence != "" or assistant_sentence != ""
-    user_name = "Visiter" if user_name == ""
+    user_name = "Visitor" if user_name == ""
     assistant_name = "Assistant" if assistant_name == ""
-    pasttalk = sprintf("時刻 %s のユーザの「%s」としての発言: %s\n" \
-      +             "時刻 %s のassistantの「%s」としての発言: %s\n", \
-      nowstr, nowstr, user_name, user_sentence, assistant_name, assistant_sentence)
+    pasttalk = sprintf(
+      "時刻 %s のユーザの「%s」としての発言: %s\n" +
+      "時刻 %s のassistantの「%s」としての発言: %s\n",
+      nowstr, user_name, user_sentence,
+      nowstr, assistant_name, assistant_sentence
+    )
   else
     pasttalk = ""
   end
   timestr = ""
   user_name = user_name_new
-  user_name = "Visiter" if user_name == ""
+  user_name = "Visitor" if user_name == ""
   assistant_name = assistant_name_new
   assistant_name = "Assistant" if assistant_name == ""
   user_sentence = user_sentence_new
@@ -112,7 +115,7 @@ Content-type: text/html
       <input type="submit" name="submit" value="OK" />
       &nbsp; &nbsp;
       <input type="submit" name="submit" value="CLEAR" />
-      </dev>
+      </div>
     </form>
     <br />
     <div style="text-align: right;">GPT</div>

--- a/sall_oa.rb
+++ b/sall_oa.rb
@@ -46,9 +46,12 @@ def main()
       time = Time::now - time0
       printf("%s(%.1f sec, %s) %s : %s\n", Time::now.strftime("%T"), time, $LLMODEL, assistant_name, assistant_sentence)
       nowstr = Time::now.strftime("%F %T")
-      pasttalk = sprintf("時刻 %s のユーザの「%s」としての発言: %s\n" \
-        +             "時刻 %s のassistantの「%s」としての発言: %s\n", \
-        nowstr, nowstr, user_name, user_sentence, assistant_name, assistant_sentence)
+      pasttalk = sprintf(
+        "時刻 %s のユーザの「%s」としての発言: %s\n" +
+        "時刻 %s のassistantの「%s」としての発言: %s\n",
+        nowstr, user_name, user_sentence,
+        nowstr, assistant_name, assistant_sentence
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary
- fix sprintf argument order so past conversation is stored correctly
- correct `Visiter` typos to `Visitor`
- close HTML `<div>` tags properly

## Testing
- `ruby -c sall.rb`
- `ruby -c sall.cgi`
- `ruby -c sall_oa.rb`
- `ruby -c sall_oa.cgi`


------
https://chatgpt.com/codex/tasks/task_e_686b2adca32883269463d74b629ba9a4